### PR TITLE
Expand API tests: anonymous-GET negative cases and WC Store API

### DIFF
--- a/tests/api/wc-store-products.spec.ts
+++ b/tests/api/wc-store-products.spec.ts
@@ -1,0 +1,71 @@
+import test, { expect } from '@playwright/test';
+
+const BASE_URL = 'https://ovcharski.com/shop/wp-json';
+const STORE_PRODUCTS = `${BASE_URL}/wc/store/v1/products`;
+const V3_PRODUCTS = `${BASE_URL}/wc/v3/products`;
+
+// The Store API (/wc/store/v1) is designed for anonymous frontend access and
+// is the right surface for read-only WooCommerce checks. The classic /wc/v3
+// API requires consumer key/secret — we deliberately do not test it with
+// credentials, only assert that it correctly rejects unauthenticated reads.
+
+test.describe('WC Store API — products (anonymous reads)', () => {
+  test('GET /products returns an array of products with expected fields', async ({ request }) => {
+    const response = await request.get(STORE_PRODUCTS, { params: { per_page: 5 } });
+    expect(response.status()).toBe(200);
+
+    const products = await response.json();
+    expect(products).toBeInstanceOf(Array);
+    expect(products.length).toBeGreaterThan(0);
+    expect(products.length).toBeLessThanOrEqual(5);
+
+    products.forEach((product: { id: number; name: string; slug: string; permalink: string }) => {
+      expect(product).toMatchObject({
+        id: expect.any(Number),
+        name: expect.any(String),
+        slug: expect.any(String),
+        permalink: expect.stringContaining('https://'),
+      });
+    });
+  });
+
+  test('pagination headers expose total counts', async ({ request }) => {
+    const response = await request.get(STORE_PRODUCTS, { params: { per_page: 1 } });
+    expect(response.status()).toBe(200);
+
+    const headers = response.headers();
+    expect(headers['x-wp-total']).toBeTruthy();
+    expect(headers['x-wp-totalpages']).toBeTruthy();
+  });
+});
+
+test.describe('WC Store API — negative cases (no credentials needed)', () => {
+  test('GET /products/{invalid-id} → 404 woocommerce_rest_product_invalid_id', async ({ request }) => {
+    const response = await request.get(`${STORE_PRODUCTS}/9999999`);
+    expect(response.status()).toBe(404);
+
+    const body = await response.json();
+    expect(body.code).toBe('woocommerce_rest_product_invalid_id');
+    expect(body.data.status).toBe(404);
+  });
+
+  test('per_page above max → 400 rest_invalid_param', async ({ request }) => {
+    const response = await request.get(STORE_PRODUCTS, { params: { per_page: 999 } });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body.code).toBe('rest_invalid_param');
+    expect(body.data.params).toHaveProperty('per_page');
+  });
+});
+
+test.describe('WC v3 API — auth boundary', () => {
+  test('GET /wc/v3/products without credentials → 401 woocommerce_rest_cannot_view', async ({ request }) => {
+    const response = await request.get(V3_PRODUCTS);
+    expect(response.status()).toBe(401);
+
+    const body = await response.json();
+    expect(body.code).toBe('woocommerce_rest_cannot_view');
+    expect(body.data.status).toBe(401);
+  });
+});

--- a/tests/api/wc-store-products.spec.ts
+++ b/tests/api/wc-store-products.spec.ts
@@ -1,8 +1,7 @@
 import test, { expect } from '@playwright/test';
 
-const BASE_URL = 'https://ovcharski.com/shop/wp-json';
-const STORE_PRODUCTS = `${BASE_URL}/wc/store/v1/products`;
-const V3_PRODUCTS = `${BASE_URL}/wc/v3/products`;
+const STORE_PRODUCTS = 'wp-json/wc/store/v1/products';
+const V3_PRODUCTS = 'wp-json/wc/v3/products';
 
 // The Store API (/wc/store/v1) is designed for anonymous frontend access and
 // is the right surface for read-only WooCommerce checks. The classic /wc/v3

--- a/tests/api/wp-invalid-ids.spec.ts
+++ b/tests/api/wp-invalid-ids.spec.ts
@@ -1,7 +1,5 @@
 import test, { expect } from '@playwright/test';
 
-const BASE_URL = 'https://ovcharski.com/shop/wp-json/wp/v2';
-
 // WP's REST router treats non-numeric IDs as a route mismatch (not a
 // validation error), so the response is always rest_no_route / 404.
 // Parameterized to prove this holds uniformly across endpoints.
@@ -15,7 +13,7 @@ const endpoints = [
 test.describe('WP — invalid resource IDs return 404 rest_no_route', () => {
   endpoints.forEach(({ name, path }) => {
     test(`GET /${name}/invalid_id → 404`, async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${path}/invalid_id`);
+      const response = await request.get(`wp-json/wp/v2/${path}/invalid_id`);
       expect(response.status()).toBe(404);
 
       const body = await response.json();

--- a/tests/api/wp-invalid-ids.spec.ts
+++ b/tests/api/wp-invalid-ids.spec.ts
@@ -1,0 +1,26 @@
+import test, { expect } from '@playwright/test';
+
+const BASE_URL = 'https://ovcharski.com/shop/wp-json/wp/v2';
+
+// WP's REST router treats non-numeric IDs as a route mismatch (not a
+// validation error), so the response is always rest_no_route / 404.
+// Parameterized to prove this holds uniformly across endpoints.
+const endpoints = [
+  { name: 'pages', path: 'pages' },
+  { name: 'categories', path: 'categories' },
+  { name: 'media', path: 'media' },
+  { name: 'tags', path: 'tags' },
+];
+
+test.describe('WP — invalid resource IDs return 404 rest_no_route', () => {
+  endpoints.forEach(({ name, path }) => {
+    test(`GET /${name}/invalid_id → 404`, async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/${path}/invalid_id`);
+      expect(response.status()).toBe(404);
+
+      const body = await response.json();
+      expect(body.code).toBe('rest_no_route');
+      expect(body.data.status).toBe(404);
+    });
+  });
+});

--- a/tests/api/wp-posts.spec.ts
+++ b/tests/api/wp-posts.spec.ts
@@ -1,7 +1,6 @@
 import test, { expect } from '@playwright/test';
 
-const BASE_URL = 'https://ovcharski.com/shop/wp-json';
-const POSTS = `${BASE_URL}/wp/v2/posts`;
+const POSTS = 'wp-json/wp/v2/posts';
 
 test.describe('WP /posts — pagination boundaries', () => {
   const invalidPerPage = [
@@ -106,7 +105,7 @@ test.describe('WP /posts — _fields filter behavior', () => {
 
 test.describe('WP /posts — unsupported namespace', () => {
   test('GET /wp/v99/posts → 404 rest_no_route', async ({ request }) => {
-    const response = await request.get(`${BASE_URL}/wp/v99/posts`);
+    const response = await request.get('wp-json/wp/v99/posts');
     expect(response.status()).toBe(404);
 
     const body = await response.json();

--- a/tests/api/wp-posts.spec.ts
+++ b/tests/api/wp-posts.spec.ts
@@ -1,0 +1,116 @@
+import test, { expect } from '@playwright/test';
+
+const BASE_URL = 'https://ovcharski.com/shop/wp-json';
+const POSTS = `${BASE_URL}/wp/v2/posts`;
+
+test.describe('WP /posts — pagination boundaries', () => {
+  const invalidPerPage = [
+    { label: 'above max (999)', value: 999 },
+    { label: 'negative (-1)', value: -1 },
+    { label: 'zero (0)', value: 0 },
+  ];
+
+  invalidPerPage.forEach(({ label, value }) => {
+    test(`per_page ${label} → 400 rest_invalid_param`, async ({ request }) => {
+      const response = await request.get(POSTS, { params: { per_page: value } });
+      expect(response.status()).toBe(400);
+
+      const body = await response.json();
+      expect(body.code).toBe('rest_invalid_param');
+      expect(body.data.status).toBe(400);
+      expect(body.data.params).toHaveProperty('per_page');
+    });
+  });
+
+  test('page=0 → 400 rest_invalid_param', async ({ request }) => {
+    const response = await request.get(POSTS, { params: { page: 0 } });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body.code).toBe('rest_invalid_param');
+    expect(body.data.params).toHaveProperty('page');
+  });
+
+  test('page far beyond available → 400 rest_post_invalid_page_number', async ({ request }) => {
+    const response = await request.get(POSTS, { params: { page: 99999 } });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body.code).toBe('rest_post_invalid_page_number');
+  });
+});
+
+test.describe('WP /posts — invalid query params', () => {
+  test('orderby with unknown value → 400 rest_invalid_param', async ({ request }) => {
+    const response = await request.get(POSTS, { params: { orderby: 'bogus' } });
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+    expect(body.code).toBe('rest_invalid_param');
+    expect(body.data.params).toHaveProperty('orderby');
+    // The error message enumerates the allowed values — useful for catching
+    // server-side enum changes.
+    expect(body.data.params.orderby).toMatch(/orderby is not one of/);
+  });
+});
+
+test.describe('WP /posts — search edge cases', () => {
+  const searchInputs = [
+    { label: 'empty', value: '' },
+    { label: 'special chars (<script>)', value: '<script>alert(1)</script>' },
+    { label: 'sql-ish', value: "' OR 1=1 --" },
+    { label: 'very long (500 chars)', value: 'a'.repeat(500) },
+  ];
+
+  searchInputs.forEach(({ label, value }) => {
+    test(`search "${label}" returns 200 without server error`, async ({ request }) => {
+      const response = await request.get(POSTS, {
+        params: { search: value, _fields: 'id,title' },
+      });
+      expect(response.status()).toBe(200);
+
+      const body = await response.json();
+      expect(body).toBeInstanceOf(Array);
+    });
+  });
+
+  test('search with <script> payload is not echoed unsanitized in titles', async ({ request }) => {
+    const payload = '<script>alert(1)</script>';
+    const response = await request.get(POSTS, {
+      params: { search: payload, _fields: 'id,title' },
+    });
+    expect(response.status()).toBe(200);
+
+    const posts: Array<{ id: number; title: { rendered: string } }> = await response.json();
+    // No rendered title should contain the raw, unsanitized payload.
+    posts.forEach((post) => {
+      expect(post.title.rendered).not.toContain('<script>');
+    });
+  });
+});
+
+test.describe('WP /posts — _fields filter behavior', () => {
+  test('_fields with nonexistent field returns empty objects (no error)', async ({ request }) => {
+    const response = await request.get(POSTS, { params: { _fields: 'does_not_exist' } });
+    expect(response.status()).toBe(200);
+
+    const body: Array<Record<string, unknown>> = await response.json();
+    expect(body).toBeInstanceOf(Array);
+    // Each item is an object stripped of all known fields.
+    body.forEach((item) => {
+      expect(item).not.toHaveProperty('id');
+      expect(item).not.toHaveProperty('title');
+    });
+  });
+});
+
+test.describe('WP /posts — unsupported namespace', () => {
+  test('GET /wp/v99/posts → 404 rest_no_route', async ({ request }) => {
+    const response = await request.get(`${BASE_URL}/wp/v99/posts`);
+    expect(response.status()).toBe(404);
+
+    const body = await response.json();
+    expect(body.code).toBe('rest_no_route');
+    expect(body.data.status).toBe(404);
+  });
+});

--- a/tests/api/wp-rest-smoke.spec.ts
+++ b/tests/api/wp-rest-smoke.spec.ts
@@ -1,13 +1,12 @@
 import test, { expect } from '@playwright/test';
 
-const BASE_URL = 'https://ovcharski.com/shop/wp-json';
 const API_VERSION = 'wp/v2';
 
 test.describe('WordPress API Tests', () => {
   
   test.describe('Core API Endpoints', () => {
     test('GET /wp/v2 should return API structure', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/`);
+      const response = await request.get(`wp-json/${API_VERSION}/`);
       await expect(response).toBeOK();
       const body = await response.json();
       
@@ -19,7 +18,7 @@ test.describe('WordPress API Tests', () => {
 
   test.describe('Content Endpoints', () => {
     test('GET /pages should return pages with required fields', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/pages`, {
+      const response = await request.get(`wp-json/${API_VERSION}/pages`, {
         params: { _fields: 'id,link,slug' }
       });
       
@@ -38,7 +37,7 @@ test.describe('WordPress API Tests', () => {
 
     test('GET /posts should support pagination', async ({ request }) => {
       const perPage = 3;
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/posts`, {
+      const response = await request.get(`wp-json/${API_VERSION}/posts`, {
         params: {
           per_page: perPage,
           _fields: 'id'
@@ -55,7 +54,7 @@ test.describe('WordPress API Tests', () => {
 
   test.describe('Taxonomy Endpoints', () => {
     test('GET /categories should return categories with expected structure', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/categories`, {
+      const response = await request.get(`wp-json/${API_VERSION}/categories`, {
         params: { _fields: 'id,name,slug' }
       });
       
@@ -75,7 +74,7 @@ test.describe('WordPress API Tests', () => {
 
   test.describe('Media Management', () => {
     test('GET /media should return valid media items', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/media`, {
+      const response = await request.get(`wp-json/${API_VERSION}/media`, {
         params: { _fields: 'id,source_url,alt_text' }
       });
       
@@ -95,12 +94,12 @@ test.describe('WordPress API Tests', () => {
 
   test.describe('Error Handling', () => {
     test('GET non-existent endpoint should return 404', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/invalid-endpoint`);
+      const response = await request.get('wp-json/invalid-endpoint');
       expect(response.status()).toBe(404);
     });
 
     test('GET invalid post ID should return 404', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/posts/invalid_id`);
+      const response = await request.get(`wp-json/${API_VERSION}/posts/invalid_id`);
       expect(response.status()).toBe(404);
     });
   });
@@ -108,7 +107,7 @@ test.describe('WordPress API Tests', () => {
   test.describe('Search Functionality', () => {
     test('Search for posts should return relevant results', async ({ request }) => {
       const searchTerm = 'hello';
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/posts`, {
+      const response = await request.get(`wp-json/${API_VERSION}/posts`, {
         params: {
           search: searchTerm,
           _fields: 'id,title,slug'
@@ -127,7 +126,7 @@ test.describe('WordPress API Tests', () => {
 
   test.describe('User Management', () => {
     test('GET /users should not expose sensitive information', async ({ request }) => {
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/users`, {
+      const response = await request.get(`wp-json/${API_VERSION}/users`, {
         params: { _fields: 'id,name,slug' }
       });
       
@@ -144,13 +143,13 @@ test.describe('WordPress API Tests', () => {
 
   test.describe('Comment System', () => {
     test('GET /comments should return comments for valid post', async ({ request }) => {
-      const postsResponse = await request.get(`${BASE_URL}/${API_VERSION}/posts`);
+      const postsResponse = await request.get(`wp-json/${API_VERSION}/posts`);
       const posts = await postsResponse.json();
       const postId = posts[0]?.id;
       
       test.skip(!postId, 'No posts available for comment testing');
       
-      const response = await request.get(`${BASE_URL}/${API_VERSION}/comments`, {
+      const response = await request.get(`wp-json/${API_VERSION}/comments`, {
         params: { post: postId }
       });
       


### PR DESCRIPTION
Adds 22 new tests across three spec files, organized by endpoint, all limited to anonymous GET requests (no credentials, no writes) since the target is a shared public demo site.

- tests/api/wp-posts.spec.ts: pagination boundaries (per_page 999/-1/0, page 0/99999), invalid orderby, search edge cases (empty, <script>, SQL-ish, 500-char input), _fields filter behavior, unsupported namespace (wp/v99).
- tests/api/wp-invalid-ids.spec.ts: parameterized 404 checks for invalid IDs across /pages, /categories, /media, /tags.
- tests/api/wc-store-products.spec.ts: anonymous reads via /wc/store/v1/products, invalid product ID, per_page bound, and the /wc/v3/products 401 auth boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands API test coverage with 22 anonymous GET tests for WordPress and WooCommerce, covering pagination, search edge cases, invalid IDs, and WC Store API reads. Also refactors specs to use the config `baseURL` and renames the smoke suite for clarity.

- New Features
  - tests/api/wp-posts.spec.ts: pagination bounds (`per_page` 999/-1/0, `page` 0/99999), invalid `orderby`, search edge cases (empty, `<script>`, SQL-ish, 500 chars), `_fields` filtering, unsupported namespace (`/wp/v99/posts`).
  - tests/api/wp-invalid-ids.spec.ts: parameterized 404 `rest_no_route` for non-numeric IDs on `/pages`, `/categories`, `/media`, `/tags`.
  - tests/api/wc-store-products.spec.ts: anonymous reads from `/wc/store/v1/products` (fields, pagination headers, bounds), invalid product ID → 404, `per_page` > max → 400, unauthenticated `/wc/v3/products` → 401.

- Refactors
  - Use Playwright config `baseURL`; pass relative `wp-json/...` paths and remove duplicated BASE_URL constants.
  - Rename `api.spec.ts` to `wp-rest-smoke.spec.ts` to reflect broad smoke coverage.

<sup>Written for commit 56bac2e47b790bffea91505b645d7e9537aa0ce0. Summary will update on new commits. <a href="https://cubic.dev/pr/ovcharski/playwright-e2e/pull/23?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

