### PR TITLE
Sync docs with current code and add behavioral guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ test.use({ storageState: './NoAuth.json' });
 - **Test timeout**: 30s
 - **Expect timeout**: 15s
 - **Browser**: Chromium only
-- **Video**: Always recorded
+- **Video**: `retain-on-failure`; trace: `on-first-retry`
 - **CI**: Single worker, 2 retries
 
 ## Key Patterns
@@ -91,12 +91,56 @@ Tests interact with Stripe iframe using `page.frameLocator()` and test card numb
 - `@playwright/test`: Test framework
 - `@axe-core/playwright`: Accessibility testing
 - `@faker-js/faker`: Test data generation
-- `dotenv`: Env-var loading (used in `global-setup.ts`, `playwright.config.ts`, and some specs)
-- `csv-parser`, `csvtojson`: CSV-driven test data
+- `dotenv`: Env-var loading (used in `global-setup.ts` only; the `playwright.config.ts` hook is commented out)
+- `csv-parser`, `csvtojson`: currently unused — no spec reads CSV data (`assets/searchData.csv` is also unreferenced)
 - `eslint` with `@typescript-eslint/*`: Linting (config in `eslint.config.js`)
 
 ## Related Docs
 
 - `README.md`: Public-facing project intro and setup
 - `IMPROVEMENTS.md`: Tracked improvement ideas and rationale
-- `plawryghtchanges.md`: Running change log
+- `plawryghtchanges.md`: Digest of Playwright release notes (not a project change log)
+
+## Behavioral Guidelines
+
+Adapted from [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills). Bias toward caution over speed; use judgment for trivial tasks.
+
+### 1. Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+- State assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+### 3. Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove imports/variables/functions that *your* changes made unused; leave pre-existing dead code alone unless asked.
+- Test: every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+Define success criteria. Loop until verified.
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan with a verify step for each item.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,146 +1,95 @@
-# 🔧 Improvements Needed
+# Improvements
 
-This document outlines recommended improvements to enhance test coverage, configuration, and code quality for the Playwright E2E testing framework.
+This document tracks the roadmap for the framework. It's also a learning aid — if you're new to Playwright or QA automation, the "Good first contributions" section is a deliberate on-ramp, and the completed items below show patterns worth studying before changing them.
 
-## Test Coverage Gaps
+For architecture and commands, see [CLAUDE.md](./CLAUDE.md) and [README.md](./README.md).
 
-### Missing Critical User Flows
-- ~~**No logout tests**~~ - ✅ **COMPLETED** - `tests/e2e/logout.spec.ts` created with logout functionality in `LoginPage.ts`
-- **No shopping cart tests** - Missing add/remove/update cart item operations
-- **No password reset flow** - Missing forgot password and reset password tests
-- **Limited profile edit scenarios** - Only basic profile update is tested, need edge cases
-- **Guest checkout missing** - Need to test checkout flow without authentication
+## Already in place
 
-### Recommended Actions
-1. ~~Create `tests/e2e/logout.spec.ts` to verify logout functionality~~ - ✅ **COMPLETED**
-2. Create `tests/e2e/shopping-cart.spec.ts` for cart operations (add, remove, update quantity, clear cart)
-3. Create `tests/e2e/password-reset.spec.ts` for password recovery flow
-4. Expand `tests/e2e/profile-edit.spec.ts` with validation tests (invalid data, character limits)
-5. Create `tests/e2e/checkout-guest.spec.ts` using `test.use({ storageState: './NoAuth.json' })`
+These used to be on the todo list and are now implemented. They're listed here so learners can see *what good looks like* in this codebase.
 
-## Configuration Issues
+- **Environment variables.** Credentials are read from `.env` in `global-setup.ts` via `dotenv`. A `.env.example` template ships with the repo.
+- **Video/trace strategy.** `video: 'retain-on-failure'` and `trace: 'on-first-retry'` in `playwright.config.ts` — keeps CI artifacts small without losing debug signal.
+- **Typed Page Object Model.** `BasePage` methods take `Locator` objects (not raw selectors), preserving Playwright's auto-waiting and type safety. Study `pages/BasePage.ts` first; every other page extends it.
+- **Reused auth state.** `global-setup.ts` logs in once and persists state to `LoginAuth.json`; tests that need an anonymous session opt in with `test.use({ storageState: './NoAuth.json' })`.
+- **Data-driven tests.** See `tests/e2e/search.spec.ts`, `tests/e2e/register.spec.ts`, and `tests/e2e/make-order-stripe.spec.ts` for the pattern — one `forEach` over a scenario array instead of copy-pasted test blocks.
+- **Dynamic Stripe expiry.** `make-order-stripe.spec.ts` computes an expiry date from `getFullYear() + 3` rather than hard-coding a year that will eventually expire.
+- **Refactored mobile viewport tests.** `tests/ui/open-homepage-mobile-refactored.spec.ts` replaces the earlier duplicated spec.
+- **Visual regression.** `tests/ui/logo-compare.spec.ts` with snapshot baselines. Update baselines with `npx playwright test --update-snapshots` after an intentional UI change.
+- **CI on every push/PR.** `.github/workflows/playwright.yml` runs the suite on `ubuntu-latest` for pushes and PRs against `main`/`master`. Uploads the HTML report as a 30-day artifact.
+- **Accessibility checks.** `tests/e2e/accessibility-scan.spec.ts` uses `@axe-core/playwright`.
+- **Logout flow.** `tests/e2e/logout.spec.ts`.
+- **npm scripts.** `npm test`, `test:headed`, `test:ui`, `report`, `lint`, `lint:fix`.
+- **Centralized timeouts.** `constants/timeouts.ts` exports named constants (`SHORT`, `ERROR_MESSAGE`, `ACTION`, `UPLOAD_PROCESSING`, `IFRAME_LOAD`). Page objects import these instead of inlining numbers, so tuning a category is a one-line change.
+- **Test data factories.** `helpers/test-data.ts` exposes `buildBillingInfo()` and `buildRegistrationUser()` — thin faker wrappers that accept `Partial<>` overrides. Specs no longer repeat the 9-field billing block or the 5-field registration block inline.
+- **Checkout shipping correctness.** `CheckoutPage.fillCheckoutForm` selects `#billing_country` first (default `BG` — the only configured WooCommerce shipping zone) and waits for the `.blockUI` AJAX overlay before filling the rest. Postcode is pinned to a 4-digit Bulgarian format in the factory.
+- **API negative coverage (anonymous GET only).** `tests/api/wp-posts.spec.ts` pins pagination boundaries, invalid params, search edge cases (XSS/SQL-ish payloads), `_fields` abuse, and unsupported namespaces. `tests/api/wp-invalid-ids.spec.ts` parameterizes invalid-ID 404s across `/pages`, `/categories`, `/media`, `/tags`. `tests/api/wc-store-products.spec.ts` covers WooCommerce Store API reads (`/wc/store/v1/products`) plus the `/wc/v3` auth boundary (401 without credentials).
 
-### Browser Coverage
-- **Only Chromium enabled** - No Firefox/WebKit testing
-  - Recommended: Enable at least Firefox for cross-browser validation
-  - Update `playwright.config.ts` to uncomment Firefox and WebKit projects
+## Active improvements
 
-### Video Recording Strategy
-- **Video recording on all tests** - Use `retain-on-failure` instead
-  - Current: `video: 'on'` (wastes storage)
-  - Recommended: `video: 'retain-on-failure'` or `video: 'on-first-retry'`
-  - Update in `playwright.config.ts`
+Open work, roughly ordered by value.
 
-### Environment Configuration
-- **dotenv commented out** - Environment variables not properly loaded
-  - Ensure `dotenv` is configured in `playwright.config.ts`
-  - Create `.env.example` template for required variables
-  - Document required environment variables in README
+### Test coverage gaps
 
-### Missing Configuration
-- **No environment-specific configs** - Same config for dev/staging/prod
-  - Recommended: Create separate configs or use environment variables
-  - Example: `BASE_URL`, `API_TIMEOUT`, `TEST_USER_EMAIL`, etc.
+- **Shopping cart operations.** Add/remove/update quantity/clear cart. No `tests/e2e/shopping-cart.spec.ts` exists today.
+- **Guest checkout.** End-to-end order placement without authentication. Use `test.use({ storageState: './NoAuth.json' })`.
+- **Password reset.** Forgot-password and reset-password flows.
+- **Profile edit validation.** `edit-profile.spec.ts` only covers the happy path. Add invalid input, required-field omissions, and boundary cases.
+- **3D Secure / SCA flow.** Stripe provides test cards that trigger the SCA challenge (e.g. `4000 0027 6000 3184`). Exercise the challenge modal.
 
-## Code Quality
+### API coverage gaps
 
-### ~~Type Safety Issues~~ - ✅ **RESOLVED**
+The API suite (`tests/api/`) covers anonymous `GET`s against WordPress core (`/wp-json/wp/v2/…`) and the WooCommerce Store API (`/wc/store/v1/…`) — see "API negative coverage" above for what's already pinned down. **Scope rule for this project: anonymous `GET` only** — the demo site is shared and public, so write methods (`POST`/`PUT`/`DELETE`) and credentialed tests are deliberately out of scope to avoid polluting real data or leaking keys.
 
-~~#### pages/BasePage.ts~~
-- ~~**Problem**: Methods accept `string` selectors instead of `Locator` objects~~
-- ~~**Impact**: Bypasses Playwright's type safety and auto-waiting features~~
-- ✅ **RESOLVED** - All methods now properly use `Locator` objects:
-  - `typeIntoLocator(locator: Locator, ...)`
-  - `clickElement(locator: Locator, ...)`
-  - `verifyText(locator: Locator, ...)`
-  - `verifyTextWithOptions(locator: Locator, ...)`
-  - `verifyElementVisible(locator: Locator, ...)`
-  - `getTextContent(locator: Locator)`
-  - Note: `fillForm()` accepts string selectors by design for convenience, but converts them to Locators internally
+Within that scope, still worth adding:
 
-### Code Duplication
+- **Response schema validation.** `toMatchObject` only checks the fields you name. Bring in `zod` or `ajv` to validate the *whole* response shape against a schema — catches accidental field removals on the server side.
+- **Store API categories and tags.** `wc-store-products.spec.ts` covers `/wc/store/v1/products`; the sibling `/products/categories` and `/products/tags` endpoints accept anonymous reads too.
+- **Empty `_fields=` filter.** `wp-posts.spec.ts` asserts `?_fields=nonexistent_field` degrades gracefully; the empty `?_fields=` case is still unasserted.
 
-#### tests/ui/open-homepage-mobile.spec.ts
-- **Problem**: Repeats same test code 4 times for different viewports
-- **Impact**: Maintenance burden, violates DRY principle
-- **Recommended Fix**: Use data-driven approach
-  ```typescript
-  const viewports = [
-    { name: 'iPhone 12', width: 390, height: 844 },
-    { name: 'iPhone 13', width: 390, height: 844 },
-    // ... etc
-  ];
+### Known flake
 
-  viewports.forEach(({ name, width, height }) => {
-    test(`should open homepage on ${name}`, async ({ page }) => {
-      // test implementation
-    });
-  });
-  ```
-- **File**: `tests/ui/open-homepage-mobile.spec.ts`
+- **`tests/e2e/check-price.spec.ts`** is marked "Flaky test" with no retry config and no investigation. Likely cause: prices rendered after an AJAX call. Fixes to try, in order:
+  1. `await page.waitForLoadState('networkidle')` before assertions, or
+  2. Assert on the price locator with a web-first matcher (`await expect(locator).toHaveText(...)`) which auto-retries, or
+  3. Trace the test once (`--trace on`) and identify the exact moment the price swaps in.
 
-### Commented Code
+### Cross-browser coverage
 
-#### Incomplete Tests
-- **tests/e2e/checkout-stripe.spec.ts** - Contains commented CVC validation tests
-  - Either implement or remove commented code
-  - If keeping, add TODO comment explaining why
+- Only Chromium is enabled. Uncomment Firefox (and optionally WebKit) in `playwright.config.ts` once the suite is flake-free — running multi-browser while there's an unresolved flake just multiplies noise.
 
-- **Visual comparison tests** - Multiple commented visual regression tests
-  - Decide if visual testing is needed
-  - If yes, implement properly with baseline images
-  - If no, remove commented code
+### Configuration hardening
 
-### Flaky Tests
+- **Environment-specific configs.** Everything points at the public demo. For learners adapting this to their own site, show how to parameterize `baseURL`, timeouts, and credentials per environment (e.g. `.env.dev`, `.env.staging`).
 
-#### tests/e2e/check-price.spec.ts
-- **Problem**: Test marked as flaky
-- **Root Cause**: Likely timing issues with dynamic price loading
-- **Recommended Fix**:
-  1. Review price verification logic in `ProductPage.ts`
-  2. Add proper wait conditions before price assertions
-  3. Check if prices are loaded via AJAX/JavaScript
-  4. Consider adding `page.waitForLoadState('networkidle')` before verification
+## Good first contributions
 
-## Priority Recommendations
+If you're using this repo to learn, these are deliberately chosen to teach one concept each without requiring broad changes.
 
-### High Priority
-1. Fix flaky test in `tests/e2e/check-price.spec.ts`
-2. Enable `video: 'retain-on-failure'` to save CI storage
-3. ~~Fix type safety in `BasePage.ts`~~ - ✅ **COMPLETED**
-4. Add shopping cart tests (critical user flow)
+1. **Write `tests/e2e/shopping-cart.spec.ts`.** Teaches: creating a new Page Object (`CartPage.ts`), locator strategy, and the add/remove/assert loop. Start with "add one item, assert cart count = 1".
+2. **Fix the flake in `check-price.spec.ts`.** Teaches: diagnosing timing bugs, reading traces, and the difference between `waitFor` and web-first assertions.
+3. **Enable Firefox in `playwright.config.ts`.** Teaches: the project system, reading the config, and interpreting cross-browser failures. Do this *after* #2 — running multi-browser while there's an unresolved flake just multiplies noise.
 
-### Medium Priority
-5. Refactor duplicated mobile viewport tests
-6. ~~Add logout tests~~ - ✅ **COMPLETED**
-7. Enable Firefox browser testing
-8. Add guest checkout tests
+When picking one, read the relevant existing file first, then open a PR with a short description of what you learned.
 
-### Low Priority
-9. Remove commented code or implement missing tests
-10. Add password reset flow tests
-11. Expand profile edit test scenarios
-12. Create environment-specific configurations
+## Stretch goals
 
-## Implementation Order
+Advanced tasks — take these on once you're comfortable with the patterns above.
 
-1. **Quick Wins** (1-2 hours):
-   - Update video recording config
-   - Remove commented code
-   - Refactor mobile viewport tests
+- **Custom fixtures.** `fixtures/test-fixtures.ts` with pre-built fixtures for `loggedInPage`, `productInCart`, `checkoutWithBilling`. Reduces boilerplate in specs.
+- **API + UI combined flows.** Seed state via the REST API (from `tests/api/`), then validate in the UI. Faster than clicking through setup.
+- **Performance baselines.** Record Navigation Timing / LCP metrics and assert they stay within budget. The official Playwright docs cover this but it's not wired up here.
+- **BDD layer.** Add `playwright-bdd` or `@cucumber/cucumber` on top of the existing specs for stakeholder-readable scenarios.
+- **Parallel-safe test data.** The current suite runs with `workers: 1`. Making it parallel-safe means generating isolated data per worker (Faker + unique suffixes) and handling WooCommerce rate limits.
 
-2. **Test Coverage** (~~4-6~~ 2-4 hours):
-   - ~~Add logout tests~~ - ✅ **COMPLETED**
-   - Add shopping cart tests
-   - Add guest checkout tests
+## Common gotchas worth knowing
 
-3. **Code Quality** (~~3-4~~ 2-3 hours):
-   - ~~Fix type safety in BasePage~~ - ✅ **COMPLETED**
-   - Investigate and fix flaky test
-   - Enable Firefox testing
+Surfacing these up-front saves an afternoon of debugging.
 
-4. **Long-term** (Ongoing):
-   - Environment-specific configurations
-   - Password reset flow
-   - Expanded profile edit scenarios
-   - Visual regression testing (if needed)
+- **Stripe rejects payments without billing details.** Fill the full billing block (name, address, email, phone) before touching the card iframe. See `pages/CheckoutPage.ts`.
+- **Checkout currency is Euro.** Price strings include `,00 €` — watch out when asserting against numeric-formatted strings.
+- **Stripe lives in an iframe.** Use `page.frameLocator()`, not `page.locator()`. Test cards: `4242 4242 4242 4242` (success), `4000 0000 0000 0002` (decline), `4000 0027 6000 3184` (3DS challenge).
+- **`workers: 1` is intentional.** The demo site is shared and rate-limited. Don't bump it up without also isolating test data per worker.
+- **Auth state expires.** If `LoginAuth.json` is stale, `global-setup.ts` re-runs on the next `npx playwright test`. Delete the file to force a refresh.
+- **Only Bulgaria has a shipping zone.** WooCommerce admin on the demo site has `BG` as the sole configured shipping zone. Any other country fails with "No shipping method has been selected". `buildBillingInfo()` defaults to `BG` with a 4-digit postcode — override via `buildBillingInfo({ country: 'NL', postcode: '1234 AB' })` only if you first add that zone in admin.
+- **Visual snapshots are OS-specific.** Playwright names baselines like `…-chromium-win32.png` and `…-chromium-linux.png` separately. The committed baseline here was generated on Windows; CI runs on Linux. Expect visual tests to fail on CI until you generate a Linux baseline (run the suite once, commit the new `*-linux.png`, or generate both locally with Docker).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Playwright logo](/assets/images/playwright-logo.png 'Playwright logo')
 
-![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
 ![Playwright](https://img.shields.io/badge/playwright-latest-green)
 
 Demo automation testing framework created with Playwright, a NodeJS library made for browser automation. It's free, open source and backed up by Microsoft.
@@ -228,19 +228,7 @@ Playwright comes with multiple built-in locators. To make tests resilient, Playw
 
 **page.getByTestId()** to locate an element based on its data-testid attribute (other attributes can be configured).
 
-# Usage
-
-Get started by installing Playwright using npm or yarn. Alternatively you can also get started and run tests using the VS Code Extension.
-
-```bash
-npm init playwright@latest
-```
-
-```bash
-yarn create playwright
-```
-
-## Running tests
+# Running tests
 
 ```bash
 npx playwright test


### PR DESCRIPTION
CLAUDE.md:
- Add behavioral guidelines section (think before coding, simplicity first, surgical changes, goal-driven execution)
- Fix stale config notes: video is retain-on-failure, not always-on; dotenv is used in global-setup.ts only
- Mark csv-parser/csvtojson as currently unused
- Describe plawryghtchanges.md accurately (Playwright release-notes digest, not a project change log)

IMPROVEMENTS.md:
- Restructure as a learning roadmap (already in place / active / good first contributions / stretch goals / gotchas)
- Update API section for PR #23: implemented negative coverage moved to the already-in-place list with real filenames; remaining gaps are schema validation, Store API categories/tags, empty _fields= case

README.md:
- Fix license badge: LICENSE.md is Apache 2.0, not MIT
- Remove the npm init playwright@latest section (scaffolds a new project - wrong advice for a cloned repo)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs to match the current test suite and adds clear contributor behavior guidelines. Also fixes the license badge and removes wrong setup advice.

- New Features
  - Added Behavioral Guidelines in `CLAUDE.md` (think before coding, simplicity first, surgical changes, goal-driven execution).

- Refactors
  - Aligned config notes in `CLAUDE.md`: video `retain-on-failure`, trace `on-first-retry`; `dotenv` used only in `global-setup.ts`; `csv-parser`/`csvtojson` marked unused; `plawryghtchanges.md` described as a Playwright release-notes digest.
  - Rewrote `IMPROVEMENTS.md` as a learning roadmap; moved implemented API negative coverage to “Already in place”; remaining gaps: schema validation, Store API categories/tags, empty `_fields=` case.
  - `README.md`: set license badge to Apache 2.0 and removed `npm init playwright@latest` scaffolding section.

<sup>Written for commit 5c098a43b9045189a1a81f4d5e80fa01d71a1a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ovcharski/playwright-e2e/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

