### PR TITLE
Fail fast when global setup login fails

### DIFF
--- a/global-setup.ts
+++ b/global-setup.ts
@@ -31,6 +31,9 @@ async function globalSetup() {
         await page.context().storageState({ path: './LoginAuth.json' });
     } catch (error) {
         console.error('Error during global setup:', error);
+        // Rethrow so a failed login aborts the run — otherwise every test
+        // proceeds with missing/stale auth state and fails confusingly.
+        throw error;
     } finally {
         if (browser) {
             await browser.close();


### PR DESCRIPTION
Previously the catch block logged the error and returned normally, so a failed login let the entire suite run with missing or stale LoginAuth.json state and fail confusingly. Rethrow so the run aborts at setup instead.

Verified: with bad credentials the run now exits 1 with zero tests executed; with valid credentials the suite runs as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast in global setup: rethrow login errors so the run exits immediately instead of running tests with missing or stale auth state. This prevents confusing failures when `LoginAuth.json` is missing or outdated.

<sup>Written for commit 92d5f400db049a260f7a1cfe664abd2f41ecf518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ovcharski/playwright-e2e/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

